### PR TITLE
add no cache header

### DIFF
--- a/server.py
+++ b/server.py
@@ -7,6 +7,10 @@ from client_lib import RedisClientManager
 app = Flask(__name__)
 client_manager = RedisClientManager()
 
+@app.after_request
+def add_header(response):
+    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    return response
 
 @app.route('/', methods=['GET'])
 def root():


### PR DESCRIPTION
Observed that my GET results were getting cached therefore I was receiving the same stale token to use for my POSTs.  This change adds no-cache headers that any proxy _should_  respect.